### PR TITLE
Add `BuildRequest` and `MapValueSpecs` functions, and refactor types

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_network_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2.go
@@ -62,41 +62,6 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 	}
 }
 
-// NetworkCreateOpts contains all teh values needed to create a new network.
-type NetworkCreateOpts struct {
-	AdminStateUp *bool
-	Name         string
-	Shared       *bool
-	TenantID     string
-	ValueSpecs   map[string]string
-}
-
-// ToNetworkCreateMpa casts a networkCreateOpts struct to a map.
-func (opts NetworkCreateOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
-	n := make(map[string]interface{})
-
-	if opts.AdminStateUp != nil {
-		n["admin_state_up"] = &opts.AdminStateUp
-	}
-	if opts.Name != "" {
-		n["name"] = opts.Name
-	}
-	if opts.Shared != nil {
-		n["shared"] = &opts.Shared
-	}
-	if opts.TenantID != "" {
-		n["tenant_id"] = opts.TenantID
-	}
-
-	if opts.ValueSpecs != nil {
-		for k, v := range opts.ValueSpecs {
-			n[k] = v
-		}
-	}
-
-	return map[string]interface{}{"network": n}, nil
-}
-
 func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(d.Get("region").(string))
@@ -105,9 +70,11 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 	}
 
 	createOpts := NetworkCreateOpts{
-		Name:       d.Get("name").(string),
-		TenantID:   d.Get("tenant_id").(string),
-		ValueSpecs: MapValueSpecs(d),
+		networks.CreateOpts{
+			Name:     d.Get("name").(string),
+			TenantID: d.Get("tenant_id").(string),
+		},
+		MapValueSpecs(d),
 	}
 
 	asuRaw := d.Get("admin_state_up").(string)

--- a/builtin/providers/openstack/resource_openstack_networking_network_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2.go
@@ -107,7 +107,7 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 	createOpts := NetworkCreateOpts{
 		Name:       d.Get("name").(string),
 		TenantID:   d.Get("tenant_id").(string),
-		ValueSpecs: networkValueSpecs(d),
+		ValueSpecs: MapValueSpecs(d),
 	}
 
 	asuRaw := d.Get("admin_state_up").(string)
@@ -283,12 +283,4 @@ func waitForNetworkDelete(networkingClient *gophercloud.ServiceClient, networkId
 		log.Printf("[DEBUG] OpenStack Network %s still active.\n", networkId)
 		return n, "ACTIVE", nil
 	}
-}
-
-func networkValueSpecs(d *schema.ResourceData) map[string]string {
-	m := make(map[string]string)
-	for key, val := range d.Get("value_specs").(map[string]interface{}) {
-		m[key] = val.(string)
-	}
-	return m
 }

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -117,7 +117,7 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 	createOpts := RouterCreateOpts{
 		Name:       d.Get("name").(string),
 		TenantID:   d.Get("tenant_id").(string),
-		ValueSpecs: routerValueSpecs(d),
+		ValueSpecs: MapValueSpecs(d),
 	}
 
 	if asuRaw, ok := d.GetOk("admin_state_up"); ok {
@@ -291,12 +291,4 @@ func waitForRouterDelete(networkingClient *gophercloud.ServiceClient, routerId s
 		log.Printf("[DEBUG] OpenStack Router %s still active.\n", routerId)
 		return r, "ACTIVE", nil
 	}
-}
-
-func routerValueSpecs(d *schema.ResourceData) map[string]string {
-	m := make(map[string]string)
-	for key, val := range d.Get("value_specs").(map[string]interface{}) {
-		m[key] = val.(string)
-	}
-	return m
 }

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -63,50 +63,6 @@ func resourceNetworkingRouterV2() *schema.Resource {
 	}
 }
 
-// routerCreateOpts contains all the values needed to create a new router. There are
-// no required values.
-type RouterCreateOpts struct {
-	Name         string
-	AdminStateUp *bool
-	Distributed  *bool
-	TenantID     string
-	GatewayInfo  *routers.GatewayInfo
-	ValueSpecs   map[string]string
-}
-
-// ToRouterCreateMap casts a routerCreateOpts struct to a map.
-func (opts RouterCreateOpts) ToRouterCreateMap() (map[string]interface{}, error) {
-	r := make(map[string]interface{})
-
-	if gophercloud.MaybeString(opts.Name) != nil {
-		r["name"] = opts.Name
-	}
-
-	if opts.AdminStateUp != nil {
-		r["admin_state_up"] = opts.AdminStateUp
-	}
-
-	if opts.Distributed != nil {
-		r["distributed"] = opts.Distributed
-	}
-
-	if gophercloud.MaybeString(opts.TenantID) != nil {
-		r["tenant_id"] = opts.TenantID
-	}
-
-	if opts.GatewayInfo != nil {
-		r["external_gateway_info"] = opts.GatewayInfo
-	}
-
-	if opts.ValueSpecs != nil {
-		for k, v := range opts.ValueSpecs {
-			r[k] = v
-		}
-	}
-
-	return map[string]interface{}{"router": r}, nil
-}
-
 func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(d.Get("region").(string))
@@ -115,9 +71,11 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 	}
 
 	createOpts := RouterCreateOpts{
-		Name:       d.Get("name").(string),
-		TenantID:   d.Get("tenant_id").(string),
-		ValueSpecs: MapValueSpecs(d),
+		routers.CreateOpts{
+			Name:     d.Get("name").(string),
+			TenantID: d.Get("tenant_id").(string),
+		},
+		MapValueSpecs(d),
 	}
 
 	if asuRaw, ok := d.GetOk("admin_state_up"); ok {

--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
@@ -142,7 +142,7 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 			HostRoutes:      resourceSubnetHostRoutesV2(d),
 			EnableDHCP:      nil,
 		},
-		subnetValueSpecs(d),
+		MapValueSpecs(d),
 	}
 
 	noGateway := d.Get("no_gateway").(bool)
@@ -376,12 +376,4 @@ func waitForSubnetDelete(networkingClient *gophercloud.ServiceClient, subnetId s
 		log.Printf("[DEBUG] OpenStack Subnet %s still active.\n", subnetId)
 		return s, "ACTIVE", nil
 	}
-}
-
-func subnetValueSpecs(d *schema.ResourceData) map[string]string {
-	m := make(map[string]string)
-	for key, val := range d.Get("value_specs").(map[string]interface{}) {
-		m[key] = val.(string)
-	}
-	return m
 }

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
 
@@ -15,4 +16,16 @@ type SubnetCreateOpts struct {
 // It overrides subnets.ToSubnetCreateMap to add the ValueSpecs field.
 func (opts SubnetCreateOpts) ToSubnetCreateMap() (map[string]interface{}, error) {
 	return BuildRequest(opts, "subnet")
+}
+
+// RouterCreateOpts represents the attributes used when creating a new router.
+type RouterCreateOpts struct {
+	routers.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToRouterCreateMap casts a CreateOpts struct to a map.
+// It overrides routers.ToRouterCreateMap to add the ValueSpecs field.
+func (opts RouterCreateOpts) ToRouterCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "router")
 }

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -19,18 +19,6 @@ func (opts NetworkCreateOpts) ToNetworkCreateMap() (map[string]interface{}, erro
 	return BuildRequest(opts, "network")
 }
 
-// SubnetCreateOpts represents the attributes used when creating a new subnet.
-type SubnetCreateOpts struct {
-	subnets.CreateOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
-}
-
-// ToSubnetCreateMap casts a CreateOpts struct to a map.
-// It overrides subnets.ToSubnetCreateMap to add the ValueSpecs field.
-func (opts SubnetCreateOpts) ToSubnetCreateMap() (map[string]interface{}, error) {
-	return BuildRequest(opts, "subnet")
-}
-
 // RouterCreateOpts represents the attributes used when creating a new router.
 type RouterCreateOpts struct {
 	routers.CreateOpts
@@ -41,4 +29,16 @@ type RouterCreateOpts struct {
 // It overrides routers.ToRouterCreateMap to add the ValueSpecs field.
 func (opts RouterCreateOpts) ToRouterCreateMap() (map[string]interface{}, error) {
 	return BuildRequest(opts, "router")
+}
+
+// SubnetCreateOpts represents the attributes used when creating a new subnet.
+type SubnetCreateOpts struct {
+	subnets.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToSubnetCreateMap casts a CreateOpts struct to a map.
+// It overrides subnets.ToSubnetCreateMap to add the ValueSpecs field.
+func (opts SubnetCreateOpts) ToSubnetCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "subnet")
 }

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -1,7 +1,6 @@
 package openstack
 
 import (
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -3,8 +3,21 @@ package openstack
 import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
+
+// NetworkCreateOpts represents the attributes used when creating a new network.
+type NetworkCreateOpts struct {
+	networks.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToNetworkCreateMap casts a CreateOpts struct to a map.
+// It overrides networks.ToNetworkCreateMap to add the ValueSpecs field.
+func (opts NetworkCreateOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "network")
+}
 
 // SubnetCreateOpts represents the attributes used when creating a new subnet.
 type SubnetCreateOpts struct {

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -14,16 +14,5 @@ type SubnetCreateOpts struct {
 // ToSubnetCreateMap casts a CreateOpts struct to a map.
 // It overrides subnets.ToSubnetCreateMap to add the ValueSpecs field.
 func (opts SubnetCreateOpts) ToSubnetCreateMap() (map[string]interface{}, error) {
-	b, err := gophercloud.BuildRequestBody(opts, "")
-	if err != nil {
-		return nil, err
-	}
-
-	if opts.ValueSpecs != nil {
-		for k, v := range opts.ValueSpecs {
-			b[k] = v
-		}
-	}
-
-	return map[string]interface{}{"subnet": b}, nil
+	return BuildRequest(opts, "subnet")
 }

--- a/builtin/providers/openstack/util.go
+++ b/builtin/providers/openstack/util.go
@@ -18,6 +18,15 @@ func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 	return fmt.Errorf("%s: %s", msg, err)
 }
 
+// MapValueSpecs converts ResourceData into a map
+func MapValueSpecs(d *schema.ResourceData) map[string]string {
+	m := make(map[string]string)
+	for key, val := range d.Get("value_specs").(map[string]interface{}) {
+		m[key] = val.(string)
+	}
+	return m
+}
+
 // BuildRequest takes an opts struct and builds a request body for
 // Gophercloud to execute
 func BuildRequest(opts interface{}, parent string) (map[string]interface{}, error) {

--- a/builtin/providers/openstack/util.go
+++ b/builtin/providers/openstack/util.go
@@ -17,3 +17,21 @@ func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 
 	return fmt.Errorf("%s: %s", msg, err)
 }
+
+// BuildRequest takes an opts struct and builds a request body for
+// Gophercloud to execute
+func BuildRequest(opts interface{}, parent string) (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.ValueSpecs != nil {
+		for k, v := range opts.ValueSpecs {
+			b[k] = v
+		}
+		delete(b, "value_specs")
+	}
+
+	return map[string]interface{}{parent: b}, nil
+}

--- a/builtin/providers/openstack/util.go
+++ b/builtin/providers/openstack/util.go
@@ -26,8 +26,8 @@ func BuildRequest(opts interface{}, parent string) (map[string]interface{}, erro
 		return nil, err
 	}
 
-	if opts.ValueSpecs != nil {
-		for k, v := range opts.ValueSpecs {
+	if b["value_specs"] != nil {
+		for k, v := range b["value_specs"].(map[string]interface{}) {
 			b[k] = v
 		}
 		delete(b, "value_specs")


### PR DESCRIPTION
Refactored `openstack_networking_subnet_v2` to use new functions and types.go.
Refactored existing providers that supported `value_specs` to use `MapValueSpecs` function.
