### PR TITLE
Fix handling of Neutron networking when managing instances.

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -965,18 +965,19 @@ func getInstanceNetworks(computeClient *gophercloud.ServiceClient, d *schema.Res
 		allPages, err := tenantnetworks.List(computeClient).AllPages()
 		if err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				log.Println("[DEBUG] os-tenant-networks disabled")
 				tenantNetworkExt = false
 			}
 
+			log.Println("[DEBUG] Err looks like: %+v", err)
 			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
 				if errCode.Actual == 403 {
+					log.Println("[DEBUG] os-tenant-networks disabled.")
 					tenantNetworkExt = false
+				} else {
+					return nil, err
 				}
-
-				return nil, err
 			}
-
-			return nil, err
 		}
 
 		networkID := ""


### PR DESCRIPTION
5bf86ff3563ee46350cbc94429d441d999e953f4 seems to have broken `openstack_compute_instance_v2` when using Neutron. 

This change works for me locally, and think it replicates the previous behaviour correctly... 
